### PR TITLE
Comments can now be destroyed

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,13 @@ class CommentsController < ApplicationController
     render 'articles/show'
   end
 
+  def destroy
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    return redirect_to article_path(article) if @comment.destroyed?
+    render 'articles/show'
+  end
+
   private
 
   def article

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,4 @@
 class Article < ActiveRecord::Base
-  has_many :comments
+  has_many :comments, dependent: :destroy
   validates :title, presence: true, length: { minimum: 5 }
 end

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -7,3 +7,6 @@ p
 p
   strong Comment:
   = comment.body
+p
+= link_to 'Destroy Comment', [comment.article,comment], method: :delete,
+                                                        data: { confirm: 'Are you sure?' }


### PR DESCRIPTION
## Sumary

It is now possible to delete comment in articles

**Trello cards**:
https://trello.com/c/jqvFYoZM/24-crear-blog-base
## Test Plan
- Open a terminal.
- Go to project directory.
- Run ./bin/rails server.
- Open browser and go to http://localhost:3000/.
- Click in show to view item in detail.
- Click in destroy a comment.
## Screenshots

![destroy-comment](https://cloud.githubusercontent.com/assets/12101394/8434509/1274d936-1f22-11e5-9937-83c9a45f2a88.gif)
## Known issues
- Pop up window asking confirmation may appear more than one time
