### PR TITLE
authentication require before deleting

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,5 @@
 class CommentsController < ApplicationController
+  http_basic_authenticate_with name: Rails.application.secrets.login.user, password: Rails.application.secrets.login.password, only: :destroy
   def create
     @comment = Comment.new(comment_params.merge(article: article))
     return redirect_to article_path(article) if @comment.save

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
     commenter: "Commenter"
     destroy: "Destroy Comment"
   popup:
-    confirmation: "Are you sureeee?"
+    confirmation: "Are you sure?"
   welcome:
     heading: "Hello, Rails!"
     blog: "My Blog"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,18 @@
 
 development:
   secret_key_base: d9152db863ef36e8b88cb86548545bf3239db629ce87c2cb8c0bfb9611077fb511b745645575a800d74d213bba52f48b0ae3a9bbee74db9a742cc9d55bc3c3e9
-
+  login:
+    user: "fran"
+    password: "fran"
 test:
   secret_key_base: 9503e436fe09869665e8501a2819f183c83b919095b40f54ef2eb96e7343779dd49cb49ef0ba1b821b1028ce95e2a2ca43e52bf92dd6b6173d90631c7b960d1f
+  login:
+    user: "fran"
+    password: "fran"
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+


### PR DESCRIPTION
## Sumary

authentication will be required if deleting a comment.

**Trello cards**:
https://trello.com/c/jqvFYoZM/24-crear-blog-base
## Test Plan
- Open a terminal.
- Go to project directory.
- Run ./bin/rails server.
- Open browser and go to http://localhost:3000/.
- Click in show to view item in detail.
- Click in destroy a comment.  
- An authentication popup will appear.
## Screenshots

![popup](https://cloud.githubusercontent.com/assets/12101394/8436495/1d96880c-1f2f-11e5-92d6-631ff597b63b.gif)
## Known issues
- Pop up window asking confirmation may appear more than one time
